### PR TITLE
prevent babel from breaking

### DIFF
--- a/gulp/tasks/buildCustomJs.js
+++ b/gulp/tasks/buildCustomJs.js
@@ -27,6 +27,10 @@ gulp.task('custom-js', () => {
         .pipe(babel({
             presets: ['es2015']
         }))
+        .on('error', (e) => {
+            console.error(e);
+            this.emit('end');
+        })
         .pipe(wrap('(function(){\n"use strict";\n<%= contents %>\n})();'))
         .pipe(gulp.dest(buildParams.viewJsDir()));
 


### PR DESCRIPTION
Currently syntax error cause babel to break. We want to prevent this.