### PR TITLE
Fix the create-package gulp task

### DIFF
--- a/gulp/tasks/createPackage.js
+++ b/gulp/tasks/createPackage.js
@@ -36,7 +36,7 @@ gulp.task('create-package', function () {
             console.log(' in  : /packages');
             console.log('\r\n');
             console.log('............................................................................................................................................');
-            return gulp.src(['./primo-explore/custom/'+code+'/html/**','./primo-explore/custom/'+code+'/img/**','./primo-explore/custom/'+code+'/css/custom1.css','./primo-explore/custom/'+code+'/js/custom.js'], {base: './primo-explore/custom'})
+            return gulp.src(['./primo-explore/custom/'+code,'./primo-explore/custom/'+code+'/html/**','./primo-explore/custom/'+code+'/img/**','./primo-explore/custom/'+code+'/css/custom1.css','./primo-explore/custom/'+code+'/js/custom.js'], {base: './primo-explore/custom'})
                 .pipe(zip(code+'.zip'))
                 .pipe(gulp.dest('./packages/'));
         });


### PR DESCRIPTION
Fixes #3 

Explicitly including the view code directory in the source
files that get added to the zip file output. Without this,
the Primo Back Office complains that the zip file
"must have a root directory with the name of the view code" and
fails to load the package.