### PR TITLE
Add browsersync for custom css

### DIFF
--- a/gulp/browserSyncManager.js
+++ b/gulp/browserSyncManager.js
@@ -4,6 +4,7 @@ var browserSync = require('browser-sync');
 module.exports = {
     closeServer: closeServer,
     reloadServer: reloadServer,
+    streamToServer: streamToServer,
     startServer: startServer,
 };
 
@@ -13,6 +14,10 @@ function closeServer(label) {
 
 function reloadServer(label) {
     return browserSync.get('production').reload();
+}
+
+function streamToServer() {
+    return browserSync.get('production').stream();
 }
 
 function startServer(args) {

--- a/gulp/tasks/servers.js
+++ b/gulp/tasks/servers.js
@@ -14,9 +14,13 @@ let prompt = require('prompt');
 
 
 
-gulp.task('setup_watchers', ['watch-js'], () => {
+gulp.task('setup_watchers', ['watch-js', 'watch-css'], () => {
     gulp.watch(config.buildParams.customPath(),() => {
         return browserSyncManager.reloadServer();
+    });
+    gulp.watch(config.buildParams.customCssPath(),() => {
+        return gulp.src(config.buildParams.customCssPath())
+            .pipe(browserSyncManager.streamToServer());
     });
 });
 


### PR DESCRIPTION
Use browsersync.stream() to watch and stream update the custom CSS file
(custom1.css).

Side note: naming in `config.js` isn't very intuitive! Why is `*.css` called "main path", while "custom1.css" is called "path", for instance? And why mix "view" and "custom" as prefix?
- viewCssDir: primo-explore/custom/${view}/css
- customCssMainPath: primo-explore/custom/${view}/css/*.css
- customCssPath: primo-explore/custom/${view}/css/custom1.css

There's also lots of duplication, only some of the functions make use of other functions.
