### PR TITLE
Fix run task: load the centralCustom module

### DIFF
--- a/gulp/primoProxy.js
+++ b/gulp/primoProxy.js
@@ -15,6 +15,7 @@ module.exports.getCustimazationObject = function (vid) {
     var base_path = 'custom/';
     var customizationObject = {
         viewJs: '',
+        centralJs: '',
         viewCss: '',
         centralCss: '',
         favIcon: '',
@@ -51,7 +52,8 @@ module.exports.getCustimazationObject = function (vid) {
     customizationObject.viewCss = glob.sync(viewPackage + "/css/custom1.css", {cwd:'primo-explore'});
 
     if (isInherited) {
-        customizationObject.centralCss = glob.sync(base_path + 'CENTRAL_PACKAGE' + "/css/custom1.css", {cwd:'primo-explore'})
+        customizationObject.centralCss = glob.sync(base_path + 'CENTRAL_PACKAGE' + "/css/custom1.css", {cwd:'primo-explore'});
+        customizationObject.centralJs = glob.sync(base_path + 'CENTRAL_PACKAGE' + "/js/custom.js", {cwd:'primo-explore'});
     }
 
     //images


### PR DESCRIPTION
Fixes #17 

When a CENTRAL_PACKAGE is uploaded to Primo, the bootstrapping
process loads the centralCustom module from the package's
custom.js file. This fix ensures that the same behavior occurs
in the local server proxy by setting the `customJs` property
on the customization object when the `run` task is executed.