### PR TITLE
Fix the app-css task

### DIFF
--- a/gulp/tasks/build-scss.js
+++ b/gulp/tasks/build-scss.js
@@ -38,7 +38,7 @@ gulp.task('extract-scss-files', () => {
         .pipe(tar.extract('.'))
 });
 gulp.task('color-variables',() => {
-    let colorVariables =JSON.parse(fs.readFileSync('colors.json', 'utf8'));
+    let colorVariables =JSON.parse(fs.readFileSync(config.viewCssDir() + '/../colors.json', 'utf8'));
     console.log(colorVariables.links);
     return gulp.src(templateFile)
         .pipe(template(colorVariables))


### PR DESCRIPTION
Fixes #24

According to the instructions, the colors.json file should
exist in the views directory root, but this task is actually
reading from the project root dir because gulp automatically
performs a cwd to the gulpfile.js location.

This fix makes the task behavior consistent with the README,
which is presumably ideal.
