### PR TITLE
enable copying images from npm packages

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -48,7 +48,7 @@ function mainJsPath() {
 }
 
 function mainImgPath() {
-    return viewImgDir()+'/*.{png, ico, gif, jpg}';
+    return viewImgDir()+'/*.{png, ico, gif, jpg, svg}';
 }
 
 function customCssMainPath() {
@@ -84,7 +84,7 @@ function customNpmCssPath() {
 }
 
 function customNpmImgPath() {
-    return `primo-explore/custom/${view}/node_modules/primo-explore*/img/*.{png, ico, gif, jpg}`;
+    return `primo-explore/custom/${view}/node_modules/primo-explore*/img/*.{png, ico, gif, jpg, svg}`;
 }
 
 

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -35,12 +35,20 @@ function viewJsDir() {
     return `primo-explore/custom/${view}/js`;
 }
 
+function viewImgDir() {
+    return `primo-explore/custom/${view}/img`;
+}
+
 function mainPath() {
     return viewJsDir()+'/*.js';
 }
 
 function mainJsPath() {
     return viewJsDir()+'/main.js';
+}
+
+function mainImgPath() {
+    return viewImgDir()+'/*.png';
 }
 
 function customCssMainPath() {
@@ -75,6 +83,10 @@ function customNpmCssPath() {
     return `primo-explore/custom/${view}/node_modules/primo-explore*/css/*.css`;
 }
 
+function customNpmImgPath() {
+    return `primo-explore/custom/${view}/node_modules/primo-explore*/img/*.png`;
+}
+
 
 
 var SERVERS = {
@@ -93,13 +105,16 @@ let buildParams = {
     customModulePath: customModulePath,
     mainPath: mainPath,
     mainJsPath: mainJsPath,
+    mainImgPath: mainImgPath,
     viewJsDir: viewJsDir,
     viewCssDir: viewCssDir,
+    viewImgDir: viewImgDir,
     customCssPath: customCssPath,
     customNpmJsPath: customNpmJsPath,
     customNpmJsCustomPath: customNpmJsCustomPath,
     customNpmJsModulePath: customNpmJsModulePath,
     customNpmCssPath: customNpmCssPath,
+    customNpmImgPath: customNpmImgPath,
     customCssMainPath: customCssMainPath,
     customColorsPath: customColorsPath
 };

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -48,7 +48,7 @@ function mainJsPath() {
 }
 
 function mainImgPath() {
-    return viewImgDir()+'/*.png';
+    return viewImgDir()+'/*.{png, ico, gif, jpg}';
 }
 
 function customCssMainPath() {
@@ -84,7 +84,7 @@ function customNpmCssPath() {
 }
 
 function customNpmImgPath() {
-    return `primo-explore/custom/${view}/node_modules/primo-explore*/img/*.png`;
+    return `primo-explore/custom/${view}/node_modules/primo-explore*/img/*.{png, ico, gif, jpg}`;
 }
 
 
@@ -127,4 +127,3 @@ module.exports = {
     getBrowserify: getBrowserify,
     setBrowserify: setBrowserify
 };
-

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const gulp = require('gulp');
+const flatten = require('gulp-flatten');
+const config = require('../config.js');
+
+let buildParams = config.buildParams;
+
+gulp.task('watch-img', () => {
+    gulp.watch([buildParams.viewImgDir(), '!'+buildParams.customNpmImgPath()],['custom-img']);
+});
+
+gulp.task('custom-img', () => {
+    return gulp.src(buildParams.customNpmImgPath())
+        .pipe(flatten())
+        .pipe(gulp.dest(buildParams.viewImgDir()));
+});

--- a/gulp/tasks/servers.js
+++ b/gulp/tasks/servers.js
@@ -14,13 +14,16 @@ let prompt = require('prompt');
 
 
 
-gulp.task('setup_watchers', ['watch-js', 'watch-css'], () => {
+gulp.task('setup_watchers', ['watch-js', 'watch-css', 'watch-img'], () => {
     gulp.watch(config.buildParams.customPath(),() => {
         return browserSyncManager.reloadServer();
     });
     gulp.watch(config.buildParams.customCssPath(),() => {
         return gulp.src(config.buildParams.customCssPath())
             .pipe(browserSyncManager.streamToServer());
+    });
+    gulp.watch(config.buildParams.mainImgPath(),() => {
+        return browserSyncManager.reloadServer();
     });
 });
 
@@ -67,7 +70,7 @@ gulp.task('connect:primo_explore', function() {
                         let hostname = parts[0];
                         let port = parts[1];
 
-                        
+
                         let options = {
                             hostname: hostname,
                             port: port,
@@ -104,4 +107,4 @@ gulp.task('connect:primo_explore', function() {
     });
 });
 
-gulp.task('run', ['connect:primo_explore','setup_watchers','custom-js','custom-css']); //watch
+gulp.task('run', ['connect:primo_explore','setup_watchers','custom-js','custom-css', 'custom-img']); //watch

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp-concat": "2.6.0",
     "gulp-cssnano": "2.1.2",
     "gulp-debug": "2.1.2",
+    "gulp-flatten": "^0.3.1",
     "gulp-plumber": "1.1.0",
     "gulp-rename": "1.2.2",
     "gulp-sass": "2.3.2",


### PR DESCRIPTION
adds a gulp task to watch for png images in the `img` folder of installed npm modules, move them to the `img` folder of the working package, and reload the browser when images are changed.

this way npm modules that require their own images to add functionality to primo (for example, [primo-explore-resource-icons](https://www.npmjs.com/package/primo-explore-resource-icons)) will have the needed images added to the package automatically.

