### PR TITLE
Since package.json contains gulp, I think you mean't gulp-cli - now gulp --tasks works

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The development package allows you to configure :
 
 -  Restart the computer
 
--  Run `npm install -g gulp` from the command line
+-  Run `npm install -g gulp-cli` from the command line
 
 -  Open a new command line window
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-sass": "2.3.2",
     "gulp-sourcemaps": "1.6.0",
     "gulp-template": "4.0.0",
+    "gulp-util": "3.0.8",
     "gulp-wrap": "0.11.0",
     "gulp-zip": "3.1.0",
     "http-response-object": "1.1.0",
@@ -40,7 +41,9 @@
     "require-dir": "0.3.0",
     "run-sequence": "1.2.1",
     "shelljs": "0.6.0",
-    "tar-fs": "1.13.0"
+    "tar-fs": "1.13.0",
+    "through2": "2.0.3",
+    "vinyl-sourcemaps-apply": "0.2.1"
   },
   "engines": {
     "node": ">=4.2"


### PR DESCRIPTION
 # A small improvement before I get started doing anything.

- Since you list `gulp` in `package.json`, you should probably have only `gulp-cli` globally.
- I added packages until `gulp --tasks` works.
- Tested on Windows with node v4.4.5