### PR TITLE
Improve handling of multiple js files

### DIFF
--- a/gulp/tasks/buildCustomJs.js
+++ b/gulp/tasks/buildCustomJs.js
@@ -15,8 +15,7 @@ const browserify = require("browserify");
 let buildParams = config.buildParams;
 
 gulp.task('watch-js', () => {
-
-    gulp.watch([buildParams.mainPath(),'!'+buildParams.customPath()],['custom-js']);
+    gulp.watch([`${buildParams.viewJsDir()}/**/*.js`,'!'+buildParams.customPath()],['custom-js']);
 });
 
 
@@ -54,6 +53,7 @@ function buildByConcatination() {
 
 function buildByBrowserify() {
     return browserify({
+        debug: true,
         entries: buildParams.mainJsPath(),
         paths:[
             buildParams.viewJsDir()+'/node_modules'


### PR DESCRIPTION
Changes the js build process as follows:
- Recursively watch the `js` directory for changes.
- Enable `debug` mode on the Browserify build. This option tells
Browserify to create source maps from `custom.js`, which are
*much* easier to read and debug:

![screen shot 2017-05-05 at 7 59 55 am](https://cloud.githubusercontent.com/assets/1045033/25748886/5c86c638-3172-11e7-8625-a50bfb04a17c.png)
