### PR TITLE
Custom html templates

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -39,6 +39,10 @@ function viewImgDir() {
     return `primo-explore/custom/${view}/img`;
 }
 
+function viewHtmlDir() {
+    return `primo-explore/custom/${view}/html`;
+}
+
 function mainPath() {
     return viewJsDir()+'/*.js';
 }
@@ -109,6 +113,7 @@ let buildParams = {
     viewJsDir: viewJsDir,
     viewCssDir: viewCssDir,
     viewImgDir: viewImgDir,
+    viewHtmlDir: viewHtmlDir,
     customCssPath: customCssPath,
     customNpmJsPath: customNpmJsPath,
     customNpmJsCustomPath: customNpmJsCustomPath,

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -46,6 +46,10 @@ function customModulePath() {
     return viewJsDir()+'/'+customModuleFile;
 }
 
+function viewHtmlDir() {
+    return `primo-explore/custom/${view}/html`;
+}
+
 function viewJsDir() {
     return `primo-explore/custom/${view}/js`;
 }
@@ -108,6 +112,7 @@ let buildParams = {
     mainPath: mainPath,
     mainJsPath: mainJsPath,
     viewJsDir: viewJsDir,
+    viewHtmlDir: viewHtmlDir,
     viewCssDir: viewCssDir,
     customCssPath: customCssPath,
     customNpmJsPath: customNpmJsPath,
@@ -130,4 +135,3 @@ module.exports = {
     getVe: getVe,
     setVe: setVe
 };
-

--- a/gulp/tasks/buildCustomHtmlTemplates.js
+++ b/gulp/tasks/buildCustomHtmlTemplates.js
@@ -1,0 +1,17 @@
+'use strict';
+const gulp = require('gulp');
+const wrap = require("gulp-wrap");
+const templateCache = require('gulp-angular-templatecache');
+const config = require('../config.js');
+
+let buildParams = config.buildParams;
+
+function prepareTemplates() {
+  gulp.src(buildParams.viewHtmlDir() + '/templates/**/*.html')
+    .pipe(templateCache({filename:'customTemplates.js', templateHeader: 'app.run(function($templateCache) {', templateFooter: '});'}))    
+    .pipe(gulp.dest(buildParams.viewJsDir()));
+}
+
+gulp.task('custom-html-templates', () => {
+  prepareTemplates();
+})

--- a/gulp/tasks/buildCustomJs.js
+++ b/gulp/tasks/buildCustomJs.js
@@ -20,7 +20,7 @@ gulp.task('watch-js', () => {
 });
 
 
-gulp.task('custom-js', () => {
+gulp.task('custom-js', ['custom-html-templates'],() => {
    if(config.getBrowserify()) {
        buildByBrowserify();
    }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "del": "2.2.1",
     "glob": "6.0.4",
     "gulp": "3.9.1",
+    "gulp-angular-templatecache": "^2.0.0",
     "gulp-autoprefixer": "3.1.0",
     "gulp-babel": "6.1.2",
     "gulp-clone": "1.0.0",


### PR DESCRIPTION
I do not like to include HTML files inside my JS files. 
With this pull-request I can save my files in the ```myView/html/templates``` directory. The files will be compiled into a ```customTemplates.js``` file. This ```$templateCache```  can be referenced with a  ```templateUrl``` from within your component

ex. ```myView/html/templates/myFile.html``` can be referenced using ```templateUrl: 'myFile.html' ``` 

```js
app.component('prmSomeComponentAfter', {
    bindings: {
        parentCtrl: '<'
    },
    templateUrl: 'myFile.html',
    controller: function() {
    // your code here
    }
  });
```
