### PR TITLE
allow to import HTML in ES6

### DIFF
--- a/gulp/tasks/buildCustomJs.js
+++ b/gulp/tasks/buildCustomJs.js
@@ -59,7 +59,7 @@ function buildByBrowserify() {
             buildParams.viewJsDir()+'/node_modules'
         ]
     })
-        .transform("babelify",{presets: ["es2015"]})
+        .transform("babelify",{presets: ["es2015"], plugins: ["transform-html-import-to-string"]})
         .bundle()
         .pipe(fs.createWriteStream(buildParams.customPath()));
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "author": "",
   "devDependencies": {
+    "babel-plugin-transform-html-import-to-string": "0.0.1",
     "babel-preset-es2015": "6.6.0",
     "babelify": "7.3.0",
     "bluebird": "3.3.1",


### PR DESCRIPTION
```javascript
import myHTML from './myPage.html'

class MyController{
 constructor(){
    console.log('Hello World');
 }
}

export let myConfig = {
  bindings: {parentCtrl: '<'}
  template: myHTML,
  controller: MyController
}
```


Imports feel more natural in ES6(browserify). 