### PR TITLE
Allow usage of SCSS in view package in order to create custom CSS

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -6,10 +6,20 @@ let customCssFile =  'custom1.css';
 let mainFile = 'main.js';
 
 let browserify;
-let view ;
-let ve ;
+let view;
+let ve;
+let useScss;
+
 function setView(_view) {
     view = _view;
+}
+
+function setUseScss(_useScss) {
+	useScss = _useScss;
+}
+
+function getUseScss() {
+	return useScss;
 }
 
 function setProxy(_proxy) {
@@ -71,6 +81,12 @@ function customColorsPath(){
 function viewCssDir() {
     return `primo-explore/custom/${view}/css`;
 }
+function customScssDir() {
+		return `primo-explore/custom/${view}/scss`;
+}
+function customScssMainPath() {
+		return customScssDir() + "/main.scss";
+}
 function customCssPath() {
     return `primo-explore/custom/${view}/css/custom1.css`;
 }
@@ -101,7 +117,7 @@ var SERVERS = {
 };
 
 /*Note that for SSL environments (https) define the server as: var PROXY_SERVER = https://your-server:443*/
-var PROXY_SERVER = 'http://il-primo17:1703';
+var PROXY_SERVER = 'http://ubz-primo.hosted.exlibrisgroup.com';
 
 
 let buildParams = {
@@ -114,6 +130,8 @@ let buildParams = {
     viewJsDir: viewJsDir,
     viewHtmlDir: viewHtmlDir,
     viewCssDir: viewCssDir,
+		customScssDir: customScssDir,
+		customScssMainPath: customScssMainPath,
     customCssPath: customCssPath,
     customNpmJsPath: customNpmJsPath,
     customNpmJsCustomPath: customNpmJsCustomPath,
@@ -127,6 +145,8 @@ module.exports = {
     buildParams: buildParams,
     PROXY_SERVER: PROXY_SERVER,
     setView: setView,
+		setUseScss: setUseScss,
+		getUseScss: getUseScss,
     setProxy: setProxy,
     proxy: getProxy,
     view: getView,

--- a/gulp/tasks/build-scss.js
+++ b/gulp/tasks/build-scss.js
@@ -48,7 +48,8 @@ gulp.task('color-variables',() => {
     return gulp.src(templateFile)
         .pipe(template(colorsMeregd))
         .pipe(rename(scssFile))
-        .pipe(gulp.dest(stylesBaseDir));
+        .pipe(gulp.dest(stylesBaseDir))
+				.pipe(gulp.dest(config.customScssDir() + "/partials"));
 });
 
 gulp.task('compile-scss',() => {
@@ -78,35 +79,6 @@ gulp.task('compile-scss',() => {
 
 gulp.task('app-css', (cb) => {
 	runSequence('extract-scss-files','color-variables', 'compile-scss', 'cleanup', cb);
-});
-
-/**
- * Task that creates a file named _variables.scss containing
- * all variables that can be used within the custom scss files of the view package
- *
- * The task needs to executed with the "view" parameter since the _variables.scss
- * will be saved in a specific view package, e.g.:
- *
- * gulp create-variables-for-custom-scss --view [viewName]
- */
-gulp.task("create-custom-scss-variables", (cb) => {
-	runSequence("extract-scss-files", "create-custom-scss-variables-partial", "cleanup");
-});
-
-/**
- * Creates the actual _variables.scss partial
- *
- * It is similar to the task "color-variables" except for the folder to which
- * the _variables.scss should be saved.
- */
-gulp.task("create-custom-scss-variables-partial", () => {
-	let colorVariables = JSON.parse(fs.readFileSync(config.viewCssDir() + '/../colors.json', 'utf8'));
-	let colorVariablesOTB =JSON.parse(fs.readFileSync(OTBColorsFile, 'utf8'));
-	let colorsMeregd = lodashMerge(colorVariablesOTB, colorVariables);
-	return gulp.src(templateFile)
-			.pipe(template(colorsMeregd))
-			.pipe(rename(scssFile))
-			.pipe(gulp.dest(config.customScssDir() + "/partials"));
 });
 
 /**

--- a/gulp/tasks/build-scss.js
+++ b/gulp/tasks/build-scss.js
@@ -2,6 +2,7 @@
 
 let autoprefixer = require('gulp-autoprefixer');
 let config = require('../config').buildParams;
+let useScss = require('../config').getUseScss;
 let proxy_server = require('../config').PROXY_SERVER
 let gulp = require('gulp');
 let cssnano = require('gulp-cssnano');
@@ -25,6 +26,7 @@ var runSequence = require('run-sequence');
 let  fs = require('fs');
 let del = require('del');
 let lodashMerge = require('lodash/merge');
+let gutil = require('gulp-util');
 
 gulp.task('cleanup',()=> del(['www']));
 
@@ -75,7 +77,80 @@ gulp.task('compile-scss',() => {
 });
 
 gulp.task('app-css', (cb) => {
-    runSequence('extract-scss-files','color-variables', 'compile-scss', 'cleanup', cb);
-
+	runSequence('extract-scss-files','color-variables', 'compile-scss', 'cleanup', cb);
 });
 
+/**
+ * Task that creates a file named _variables.scss containing
+ * all variables that can be used within the custom scss files of the view package
+ *
+ * The task needs to executed with the "view" parameter since the _variables.scss
+ * will be saved in a specific view package, e.g.:
+ *
+ * gulp create-variables-for-custom-scss --view [viewName]
+ */
+gulp.task("create-custom-scss-variables", (cb) => {
+	runSequence("extract-scss-files", "create-custom-scss-variables-partial", "cleanup");
+});
+
+/**
+ * Creates the actual _variables.scss partial
+ *
+ * It is similar to the task "color-variables" except for the folder to which
+ * the _variables.scss should be saved.
+ */
+gulp.task("create-custom-scss-variables-partial", () => {
+	let colorVariables = JSON.parse(fs.readFileSync(config.viewCssDir() + '/../colors.json', 'utf8'));
+	let colorVariablesOTB =JSON.parse(fs.readFileSync(OTBColorsFile, 'utf8'));
+	let colorsMeregd = lodashMerge(colorVariablesOTB, colorVariables);
+	return gulp.src(templateFile)
+			.pipe(template(colorsMeregd))
+			.pipe(rename(scssFile))
+			.pipe(gulp.dest(config.customScssDir() + "/partials"));
+});
+
+/**
+ * Task to watch custom scss files contained in /scss directory in view package folder
+ */
+gulp.task("watch-custom-scss", () => {
+    gulp.watch([config.customScssDir() + "/**/*.scss"], ["custom-scss"]);
+});
+
+/**
+ * Compiles the custom scss to a css file called custom-scss-compiled.css which
+ * in turn is then concatenated with all other css files present in the /css folder
+ * of the view package folder to the custom1.css file that constitutes the entirety
+ * of the view package css.
+ *
+ * Please note. The logic of this task will only execute if the run task is
+ * executed with the "useScss" parameter, e.g.:
+ *
+ * gulp run --view UNIBZ --useScss
+ */
+gulp.task("custom-scss", () => {
+	if (!useScss()) {
+		return;
+	}
+
+	gutil.log("Start Creating custom CSS from custom SCSS");
+
+	let customScss = gulp.src(config.customScssMainPath())
+		.pipe(plumber({
+				errorHandler: function (err) {
+						console.log('1111111' + err);
+						this.emit('end');
+				}
+		}))
+		// .pipe(sourcemaps.init())
+		.pipe(sass())
+		.pipe(autoprefixer({
+				browsers: ['last 2 versions'],
+				cascade: false
+		}))
+		.pipe(rename("custom-scss-compiled.css"))
+		.pipe(gulp.dest(config.viewCssDir()));
+
+	gutil.log("End Creating custom CSS from custom SCSS");
+
+	return customScss;
+});

--- a/gulp/tasks/build-scss.js
+++ b/gulp/tasks/build-scss.js
@@ -83,12 +83,15 @@ gulp.task('app-css', (cb) => {
 
 /**
  * Task to watch custom scss files contained in /scss directory in view package folder
+ *
+ * Please note. The logic of this task will only execute if the run task is
+ * executed with the "useScss" parameter, e.g.: gulp run --view UNIBZ --useScss
  */
 gulp.task("watch-custom-scss", () => {
 	if (!useScss()) {
 		return;
 	}
-	
+
 	gulp.watch([config.customScssDir() + "/**/*.scss"], ["custom-scss"]);
 });
 
@@ -99,9 +102,7 @@ gulp.task("watch-custom-scss", () => {
  * of the view package css.
  *
  * Please note. The logic of this task will only execute if the run task is
- * executed with the "useScss" parameter, e.g.:
- *
- * gulp run --view UNIBZ --useScss
+ * executed with the "useScss" parameter, e.g.: gulp run --view UNIBZ --useScss
  */
 gulp.task("custom-scss", () => {
 	if (!useScss()) {

--- a/gulp/tasks/build-scss.js
+++ b/gulp/tasks/build-scss.js
@@ -85,7 +85,11 @@ gulp.task('app-css', (cb) => {
  * Task to watch custom scss files contained in /scss directory in view package folder
  */
 gulp.task("watch-custom-scss", () => {
-    gulp.watch([config.customScssDir() + "/**/*.scss"], ["custom-scss"]);
+	if (!useScss()) {
+		return;
+	}
+	
+	gulp.watch([config.customScssDir() + "/**/*.scss"], ["custom-scss"]);
 });
 
 /**

--- a/gulp/tasks/servers.js
+++ b/gulp/tasks/servers.js
@@ -10,11 +10,12 @@ let browserSyncManager = require('../browserSyncManager');
 let primoProxy = require('../primoProxy');
 let glob = require('glob');
 let prompt = require('prompt');
+let runSequence = require('run-sequence');
 
 
 
 
-gulp.task('setup_watchers', ['watch-js', 'watch-css'], () => {
+gulp.task('setup_watchers', ['watch-js', 'watch-custom-scss', 'watch-css'], () => {
     gulp.watch(config.buildParams.customPath(),() => {
         return browserSyncManager.reloadServer();
     });
@@ -68,7 +69,7 @@ gulp.task('connect:primo_explore', function() {
                         let hostname = parts[0];
                         let port = parts[1];
 
-                        
+
                         let options = {
                             hostname: hostname,
                             port: port,
@@ -105,4 +106,4 @@ gulp.task('connect:primo_explore', function() {
     });
 });
 
-gulp.task('run', ['connect:primo_explore','setup_watchers','custom-js','custom-css']); //watch
+gulp.task('run', ['connect:primo_explore','setup_watchers','custom-js','custom-scss','custom-css']); //watch

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,4 +9,5 @@ const config = require('./gulp/config');
 var options = minimist(process.argv.slice(2));
 config.setView(options.view);
 if (options.proxy) config.setProxy(options.proxy);
+if (options.useScss) config.setUseScss(options.useScss);
 config.setBrowserify(options.browserify);


### PR DESCRIPTION
This gives the possibility to use SCSS in the view package. 

The scss declarations must be located in a file called `main.scss` which is located in a folder called `/scss` in the root directory of the view package.

It is possible to put all scss declarations directly in the `main.scss` file or to use `@import` statement to reference other scss files containing scss declarations.

In order to enable the usage of SCSS the gulp run command has to be executed with the `--useScss` parameter: `gulp run --view [viewName] --useScss`

**Workflow**

(1) In addition to the CSS and JS watcher, new watchers are registered for all *.scss files in the new `/[viewName]/scss` folder.

(2) The scss declarations in the *.scss files are compiled to CSS and saved to `/[viewName]/css/custom-scss-compiled.css`

(3) The `custom1.css` file is created using all *.css files in the folder `/[viewName]/css`

Everytime a change is made to a *.scss file, the previously registered watchers (see 1) initiate a recompilation of the `/[viewName]/css/custom-scss-compiled.css` file (see 2). This in turn triggers the CSS watchers which will then rebuild the `custom1.css` file (see 3).





