### PR TITLE
Support custom HTML templates from npm

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -127,7 +127,9 @@ function customNpmCssPath() {
     return `primo-explore/custom/${view}/node_modules/primo-explore*/css/*.css`;
 }
 
-
+function customNpmHtmlPath() {
+    return `primo-explore/custom/${view}/node_modules/primo-explore*/html/*.html`;
+}
 
 var SERVERS = {
     local: 'http://localhost:8002'
@@ -163,6 +165,7 @@ let buildParams = {
     customNpmJsCustomPath: customNpmJsCustomPath,
     customNpmJsModulePath: customNpmJsModulePath,
     customNpmCssPath: customNpmCssPath,
+    customNpmHtmlPath: customNpmHtmlPath,
     customCssMainPath: customCssMainPath,
     customColorsPath: customColorsPath
 };

--- a/gulp/tasks/buildCustomHtmlTemplates.js
+++ b/gulp/tasks/buildCustomHtmlTemplates.js
@@ -30,7 +30,7 @@ function prepareTemplates() {
         prepareTempltesWithBrowserify();
     }
     else{
-        gulp.src(buildParams.viewHtmlDir() + '/templates/**/*.html')
+        gulp.src([buildParams.viewHtmlDir() + '/templates/**/*.html', buildParams.customNpmHtmlPath()])
             .pipe(templateCache({filename:'customTemplates.js', templateHeader: 'app.run(function($templateCache) {', templateFooter: '});'}))
             .pipe(gulp.dest(buildParams.viewJsDir()));
     }


### PR DESCRIPTION
I'd like to be able to include HTML templates from npm modules. With this pull-request, you can save html templates in an `html` directory within an npm module.
For example, `node_modules/package-name/html/myFile.html` can be referenced using `templateUrl: 'package-name/html/myFile.html'`

This builds on #46 Custom HTML Templates.