### PR TITLE
Minify/uglify JavaScript in the browserify build

### DIFF
--- a/gulp/tasks/buildCustomJs.js
+++ b/gulp/tasks/buildCustomJs.js
@@ -11,6 +11,11 @@ const glob = require('glob');
 const gutil = require('gulp-util');
 const fs = require("fs");
 const browserify = require("browserify");
+const source = require('vinyl-source-stream');
+const streamify = require('gulp-streamify');
+const uglify = require('gulp-uglify');
+const buffer = require('vinyl-buffer');
+const sourcemaps = require('gulp-sourcemaps');
 
 let buildParams = config.buildParams;
 
@@ -59,7 +64,12 @@ function buildByBrowserify() {
             buildParams.viewJsDir()+'/node_modules'
         ]
     })
-        .transform("babelify",{presets: ["es2015"], plugins: ["transform-html-import-to-string"]})
+        .transform("babelify",{presets: ["es2015"], plugins: ["transform-html-import-to-string"], sourceMaps: true})
         .bundle()
-        .pipe(fs.createWriteStream(buildParams.customPath()));
+        .pipe(source(buildParams.customFile))
+        .pipe(buffer())
+        .pipe(sourcemaps.init({loadMaps: true}))
+        .pipe(uglify())
+        .pipe(sourcemaps.write('./'))
+        .pipe(gulp.dest(buildParams.viewJsDir()));
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,11 @@
     "tar-fs": "1.13.0",
     "protractor": "5.0.0",
     "fs-extra": "2.1.2",
-    "protractor-image-comparison": "1.2.3"
+    "protractor-image-comparison": "1.2.3",
+    "gulp-streamify": "1.0.2",
+    "gulp-uglify": "3.0.0",
+    "vinyl-buffer": "1.0.0",
+    "vinyl-source-stream": "1.1.0"
   },
   "engines": {
     "node": ">=4.2"


### PR DESCRIPTION
This substantially reduces the size of the custom.js file.
A source map is available when running locally.

![screen shot 2017-12-01 at 4 04 34 pm](https://user-images.githubusercontent.com/1045033/33505819-a44dbcca-d6b2-11e7-8566-9cad78e7e777.png)
