### PR TITLE
add dist/*.js files from node_modules when building by concatenation

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -122,6 +122,10 @@ function customNpmJsPath() {
     return `primo-explore/custom/${view}/node_modules/primo-explore*/js/*.js`;
 }
 
+function customNpmDistPath() {
+  return `primo-explore/custom/${view}/node_modules/primo-explore*/dist/*.js`;
+}
+
 
 function customNpmCssPath() {
     return `primo-explore/custom/${view}/node_modules/primo-explore*/css/*.css`;
@@ -160,6 +164,7 @@ let buildParams = {
     customCssPath: customCssPath,
 		customNpmModuleRootDir: customNpmModuleRootDir,
     customNpmJsPath: customNpmJsPath,
+    customNpmDistPath: customNpmDistPath,
     customNpmJsCustomPath: customNpmJsCustomPath,
     customNpmJsModulePath: customNpmJsModulePath,
     customNpmCssPath: customNpmCssPath,

--- a/gulp/tasks/buildCustomJs.js
+++ b/gulp/tasks/buildCustomJs.js
@@ -30,7 +30,7 @@ gulp.task('custom-js', ['custom-html-templates'],() => {
 });
 
 function buildByConcatination() {
-    return gulp.src([buildParams.customModulePath(),buildParams.mainPath(),buildParams.customNpmJsPath(),'!'+buildParams.customPath(),'!'+buildParams.customNpmJsModulePath(),'!'+buildParams.customNpmJsCustomPath()])
+    return gulp.src([buildParams.customModulePath(),buildParams.mainPath(),buildParams.customNpmJsPath(),buildParams.customNpmDistPath(),'!'+buildParams.customPath(),'!'+buildParams.customNpmJsModulePath(),'!'+buildParams.customNpmJsCustomPath()])
         .pipe(concat(buildParams.customFile))
         .pipe(babel({
             presets: ['es2015']


### PR DESCRIPTION
this is a minor edit that supports adding customization module code installed through npm that resides in a `dist/` folder.

**use case**: i write primo customizations using a folder structure where the "compiled" angular module for a customization is output to a `dist/` folder (as distinct from `src/` - [example](https://github.com/alliance-pcsg/primo-explore-report-problem). it's easiest to install just this file, so i `.npmignore` all of my source code and other parts of the repo, so that ideally the only thing really installed from `npm` is the customization itself. the dev env doesn't pick up js located in the `dist/` folder yet because it doesn't look for that path.

it seems like a fairly established best practice to separate source code from built code in npm packages, and i think `dist/` is a common enough location for built code, so i opened this in case anyone else develops primo customizations with this structure in the future.