### PR TITLE
Build custom code before packaging

### DIFF
--- a/gulp/tasks/build-scss.js
+++ b/gulp/tasks/build-scss.js
@@ -31,7 +31,7 @@ let gutil = require('gulp-util');
 gulp.task('cleanup',()=> del(['www']));
 
 gulp.task('extract-scss-files', ()=> {
-    let proxy_server = require('../config').PROXY_SERVER;    
+    let proxy_server = require('../config').PROXY_SERVER;
     console.log(proxy_server+'/primo-explore/lib/scsss.tar.gz');
     let url = proxy_server+'/primo-explore/lib/scsss.tar.gz';
     var headers = {
@@ -88,7 +88,7 @@ gulp.task('app-css', (cb) => {
  * Please note. The logic of this task will only execute if the run task is
  * executed with the "useScss" parameter, e.g.: gulp run --view UNIBZ --useScss
  */
-gulp.task("watch-custom-scss", () => {
+gulp.task("watch-custom-scss", ['select-view'], () => {
 	if (!useScss()) {
 		return;
 	}
@@ -105,7 +105,7 @@ gulp.task("watch-custom-scss", () => {
  * Please note. The logic of this task will only execute if the run task is
  * executed with the "useScss" parameter, e.g.: gulp run --view UNIBZ --useScss
  */
-gulp.task("custom-scss", () => {
+gulp.task("custom-scss", ['select-view'], () => {
 	if (!useScss()) {
 		return;
 	}

--- a/gulp/tasks/buildCustomCss.js
+++ b/gulp/tasks/buildCustomCss.js
@@ -11,7 +11,7 @@ var glob = require('glob');
 
 let buildParams = config.buildParams;
 
-gulp.task('watch-css', () => {
+gulp.task('watch-css', ['select-view'], () => {
 
     gulp.watch([buildParams.customCssMainPath(),buildParams.customNpmCssPath(),'!'+buildParams.customCssPath()],['custom-css']);
 });
@@ -19,11 +19,11 @@ gulp.task('watch-css', () => {
 
 
 
-gulp.task('custom-css', () => {
-    
+gulp.task('custom-css', ['select-view'], () => {
+
     return gulp.src([buildParams.customCssMainPath(),buildParams.customNpmCssPath(),'!'+buildParams.customCssPath()])
         .pipe(concat(buildParams.customCssFile))
         .pipe(gulp.dest(buildParams.viewCssDir()));
-    
+
 
 });

--- a/gulp/tasks/buildCustomHtmlTemplates.js
+++ b/gulp/tasks/buildCustomHtmlTemplates.js
@@ -36,6 +36,6 @@ function prepareTemplates() {
     }
 }
 
-gulp.task('custom-html-templates', () => {
+gulp.task('custom-html-templates', ['select-view'], () => {
     prepareTemplates();
 })

--- a/gulp/tasks/buildCustomJs.js
+++ b/gulp/tasks/buildCustomJs.js
@@ -14,12 +14,12 @@ const browserify = require("browserify");
 
 let buildParams = config.buildParams;
 
-gulp.task('watch-js', () => {
+gulp.task('watch-js', ['select-view'], () => {
     gulp.watch([`${buildParams.viewJsDir()}/**/*.js`,'!'+buildParams.customPath()],['custom-js']);
 });
 
 
-gulp.task('custom-js', ['custom-html-templates'],() => {
+gulp.task('custom-js', ['select-view', 'custom-html-templates'],() => {
    if(config.getBrowserify()) {
        buildByBrowserify();
    }

--- a/gulp/tasks/buildJsFromPrimoNodeModules.js
+++ b/gulp/tasks/buildJsFromPrimoNodeModules.js
@@ -17,7 +17,7 @@ let runSequence = require("run-sequence");
  *
  * e.g. gulp run --view [ViewName] --reinstallNodeModules
  */
-gulp.task("reinstall-primo-node-modules", function() {
+gulp.task("reinstall-primo-node-modules", ['select-view'], function() {
 	if (config.getReinstallNodeModules()) {
 		runSequence(["delete-primo-node-modules", "install-primo-node-modules"]);
 	}

--- a/gulp/tasks/createPackage.js
+++ b/gulp/tasks/createPackage.js
@@ -1,46 +1,67 @@
 'use strict';
-var gulp = require('gulp');
-let glob = require('glob');
-let prompt = require('prompt');
-let zip = require('gulp-zip');
-let config = require('../config.js');
+const gulp = require('gulp');
+const glob = require('glob');
+const prompt = require('prompt');
+const zip = require('gulp-zip');
+const config = require('../config.js');
 
-let buildParams = config.buildParams;
+gulp.task('select-view', (cb) => {
+    const basedir = 'primo-explore/custom/';
+    const customFolderExp = basedir + '*/';
+    const files = glob.sync(customFolderExp, {});
 
-gulp.task('create-package', function () {
-    var basedir = 'primo-explore/custom/';
-    var customFolderExp = basedir+'*/';
-    console.log('Please Choose a package to create:');
-    glob(customFolderExp, {}, function (er, files) {
-        // Note elision, there is no member at 2 so it isn't visited
-        console.log('\r\n');
-        files.forEach(function(element, index, array){
-            console.log(index+1 + ': '+ element.replace(basedir,'').replace('/',''));
-            console.log('\r\n');
-        });
-        prompt.start();
-        var property = {
-            name: 'package',
-            message: 'Please Choose the level you want to create the package for'
-        };
-        prompt.get(property, function (err, result) {
+    return new Promise(resolve => {
+        if (!config.view()) {
+            console.log('Please Choose a view to use:\r\n');
+            files.forEach(function(element, index, array){
+                console.log(index+1 + ': '+ element.replace(basedir,'').replace('/',''));
+                console.log('\r\n');
+            });
 
-            console.log('\r\n');
-            var code = result.package;
+            prompt.start();
+            const property = {
+                name: 'view',
+                message: 'Please Choose view to use'
+            };
+            prompt.get(property, function (err, result) {
+                console.log('\r\n');
+                let code = result.view;
 
-            if(files[result.package - 1]){
-                code = files[result.package - 1].replace(basedir,'').replace('/','');
+                if(files[result.view - 1]){
+                    code = files[result.view - 1].replace(basedir,'').replace('/','');
+                }
+                config.setView(code);
+                resolve();
+            });
+        } else {
+            let valid = false
+            for (let index in files) {
+                let dir = files[index].replace(basedir,'').replace('/','')
+
+                if(dir === config.view()) {
+                    valid = true
+                    break;
+                }
             }
-            console.log('Creating package for : ('+code+'.zip)');
-            console.log(code);
-            console.log(' in  : /packages');
-            console.log('\r\n');
-            console.log('............................................................................................................................................');
-            return gulp.src(['./primo-explore/custom/'+code,'./primo-explore/custom/'+code+'/html/**','./primo-explore/custom/'+code+'/img/**','./primo-explore/custom/'+code+'/css/custom1.css','./primo-explore/custom/'+code+'/js/custom.js'], {base: './primo-explore/custom'})
-                .pipe(zip(code+'.zip'))
-                .pipe(gulp.dest('./packages/'));
-        });
 
+            if (!valid) {
+                resolve()
+                cb("--view must be a valid view")
+            } else {
+                resolve()
+            }
+        }
     })
+})
 
+gulp.task('create-package', ['select-view', 'custom-js','custom-scss','custom-css'], function () {
+    const code = config.view();
+    console.log('Creating package for : ('+code+'.zip)');
+    console.log(code);
+    console.log(' in  : /packages');
+    console.log('\r\n');
+    console.log('............................................................................................................................................');
+    return gulp.src(['./primo-explore/custom/'+code,'./primo-explore/custom/'+code+'/html/**','./primo-explore/custom/'+code+'/img/**','./primo-explore/custom/'+code+'/css/custom1.css','./primo-explore/custom/'+code+'/js/custom.js'], {base: './primo-explore/custom'})
+        .pipe(zip(code+'.zip'))
+        .pipe(gulp.dest('./packages/'));
 });

--- a/gulp/tasks/servers.js
+++ b/gulp/tasks/servers.js
@@ -14,7 +14,7 @@ let runSequence = require('run-sequence');
 
 
 
-gulp.task('setup_watchers', ['watch-js', 'watch-custom-scss', 'watch-css'], () => {
+gulp.task('setup_watchers', ['select-view', 'watch-js', 'watch-custom-scss', 'watch-css'], () => {
     gulp.watch(config.buildParams.customPath(),() => {
         return browserSyncManager.reloadServer();
     });
@@ -26,7 +26,7 @@ gulp.task('setup_watchers', ['watch-js', 'watch-custom-scss', 'watch-css'], () =
 
 
 
-gulp.task('connect:primo_explore', function() {
+gulp.task('connect:primo_explore', ['select-view'], function() {
     let appName = 'primo-explore';
     browserSyncManager.startServer({
         label: 'production',
@@ -119,4 +119,4 @@ gulp.task('connect:primo_explore', function() {
 });
 
 
-gulp.task('run', ['connect:primo_explore','reinstall-primo-node-modules','setup_watchers','custom-js','custom-scss','custom-css']); //watch
+gulp.task('run', ['select-view', 'connect:primo_explore','reinstall-primo-node-modules','setup_watchers','custom-js','custom-scss','custom-css']); //watch


### PR DESCRIPTION
We wanted to be able to run `gulp create-package` without worrying about which view was last run or when it was run. This PR updates the gulp commands to build the custom code before the package is created. 

As a nice side-effect, this also adds the prompt for which view to use to `gulp run`, meaning `--view` is no longer necessary (but still available). It also adds the `--view` flag to `gulp create-package` so these two commands are now callable either way.

As a side note, this is my first foray into gulp tasks, and I had some difficulty getting the dependencies to wait for the view selection task, so if anyone has suggestions on a better way please speak up!