### PR TITLE
Redirect SAML login requests

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -10,10 +10,19 @@ let view;
 let ve;
 let useScss;
 let reinstallNodeModules;
+let saml;
 
 
 function setView(_view) {
     view = _view;
+}
+
+function setSaml(_saml) {
+  saml = _saml;
+}
+
+function getSaml() {
+  return saml;
 }
 
 function setUseScss(_useScss) {
@@ -189,5 +198,7 @@ module.exports = {
     getBrowserify: getBrowserify,
     setBrowserify: setBrowserify,
     getVe: getVe,
-    setVe: setVe
+    setVe: setVe,
+    getSaml: getSaml,
+    setSaml: setSaml
 };

--- a/gulp/primoProxy.js
+++ b/gulp/primoProxy.js
@@ -180,14 +180,12 @@ module.exports.getCustimazationObject = function (vid,appName) {
 module.exports.proxy_function = function () {
     var proxyServer = config.PROXY_SERVER;
     var res = new Response(200, {'content-type': 'text/css'}, new Buffer(''), '');
-
-
-
+    var loginRewriteFlags = (config.getSaml()) ? 'RL' : 'PL';
 
     return modRewrite([
         '/primo_library/libweb/webservices/rest/(.*) ' + proxyServer + '/primo_library/libweb/webservices/rest/$1 [PL]',
         '/primaws/rest/(.*) ' + proxyServer + '/primaws/rest/$1 [PL]',
-        '/primo_library/libweb/primoExploreLogin ' + proxyServer + '/primo_library/libweb/primoExploreLogin [PL]',
+        '/primo_library/libweb/primoExploreLogin ' + proxyServer + '/primo_library/libweb/primoExploreLogin [' + loginRewriteFlags + ']',
         '/primaws/suprimaLogin ' + proxyServer + '/primaws/suprimaLogin [PL]',
 
         '/primo-explore/index.html ' + proxyServer + '/primo-explore/index.html [PL]',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,3 +13,4 @@ if (options.reinstallNodeModules) config.setReinstallNodeModules(options.reinsta
 if (options.proxy) config.setProxy(options.proxy);
 if (options.useScss) config.setUseScss(options.useScss);
 config.setBrowserify(options.browserify);
+config.setSaml(options.saml);


### PR DESCRIPTION
Fixes #83 

Proxied requests to primoExploreLogin will not work for SAML
authentication (server returns a 500 error). This change adds an
optional `--saml` parameter to the gulp run task. Setting the `--saml`
parameter instructs the local proxy server to redirect (vs proxy)
any primoExploreLogin requests to the target host. When SAML
authentication is complete, Primo will redirect the browser back
to localhost.