### PR TITLE
unhide 'primo-explore/custom' and 'tmp/' directories from npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 primo-explore/custom/
 primo-explore/tmp/
+
+!primo-explore/custom/.gitignore
+!primo-explore/tmp/.gitignore
+
 .idea/
 package-lock.json

--- a/primo-explore/custom/.gitignore
+++ b/primo-explore/custom/.gitignore
@@ -1,4 +1,1 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
+# Add entries to prefixed with '!' to unhide your view files

--- a/primo-explore/tmp/.gitignore
+++ b/primo-explore/tmp/.gitignore
@@ -1,4 +1,1 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
+# Add entries to prefixed with '!' to unhide your view files


### PR DESCRIPTION
### Background
- I'm currently trying to automate the running and testing of our primo views and addons with circleci and cypress.
- I'm using the `primo-explore-devenv` [npm package](https://www.npmjs.com/package/primo-explore-devenv) to grab the code for this 
- to run a view, you have to copy over the view directory into `primo-explore/custom/`, but that directory doesn't appear in the `npm` package (reasoning below)
- it's easy to just remake it with two `mkdir` commands, but it's initially confusing and unnecessary

### Description of Changes
- this PR has the effect of making the `npm` package better reflect the git repo (ensures that the `primo-explore/custom` and `primo-explore/tmp` directories show up)
- it _does not have any effect_ on what is or is not ignored _by git_ (doesn't affect the git ignore logic )
- it only moves the clarification for those rules out of the `primo-explore/*/.gitignore` file into the main one

### Testing and Deployment
- this can be tested by running `npm pack` on each repo and comparing them
- in order to have any effect, you'll have to `npm publish` a new npm package (#74)

--------

### Implementation Details/Explanation
- in the absence of an `.npmignore`, npm defers to the `.gitignore` in order to decide what it includes/excludes from the final package [[blog article](https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d)]
- when it does this, it doesn't look into the `.gitignore`s in the rest of the repo
- this means that the 'primo-explore/*' directories are seen as empty and not included in the end result
- this leads to a disconnect between what's in the repo and what's in the installed package, complicating/confusing future attempts at automation/scripting