### PR TITLE
gulp.watch changes and docker

### DIFF
--- a/gulp/tasks/02-custom-js.js
+++ b/gulp/tasks/02-custom-js.js
@@ -18,7 +18,7 @@ let buildParams = config.buildParams;
 
 
 gulp.task('watch-js', gulp.series('select-view', (cb) => {
-    gulp.watch([`${buildParams.viewJsDir()}/**/*.js`,'!'+buildParams.customPath()],gulp.series('custom-js'));
+    gulp.watch([`${buildParams.viewJsDir()}/**/*.js`,'!'+buildParams.customPath()], {interval: 1000, usePolling: true}, gulp.series('custom-js'));
     cb();
 }));
 

--- a/gulp/tasks/03-scss.js
+++ b/gulp/tasks/03-scss.js
@@ -105,7 +105,7 @@ gulp.task("watch-custom-scss", gulp.series('select-view', (cb) => {
         cb();
         return;
 	}
-    gulp.watch(gulp.src([config.customScssDir() + "/**/*.scss"],{allowEmpty:true}), gulp.series('custom-scss'));
+    gulp.watch([config.customScssDir() + "/**/*.scss"], gulp.series('custom-scss'));
     cb();
 }));
 
@@ -126,7 +126,7 @@ gulp.task("custom-scss", gulp.series('select-view', (cb) => {
 
 	gutil.log("Start Creating custom CSS from custom SCSS");
 
-	let customScss = gulp.src(config.customScssMainPath())
+	let customScss = gulp.src(config.customScssMainPath(),{allowEmpty:true})
 		.pipe(plumber({
 				errorHandler: function (err) {
 						console.log('1111111' + err);

--- a/gulp/tasks/03-scss.js
+++ b/gulp/tasks/03-scss.js
@@ -105,7 +105,7 @@ gulp.task("watch-custom-scss", gulp.series('select-view', (cb) => {
         cb();
         return;
 	}
-    gulp.watch([config.customScssDir() + "/**/*.scss"], gulp.series('custom-scss'));
+    gulp.watch([config.customScssDir() + "/**/*.scss"], {interval: 1000, usePolling: true}, gulp.series('custom-scss'));
     cb();
 }));
 

--- a/gulp/tasks/03-scss.js
+++ b/gulp/tasks/03-scss.js
@@ -105,7 +105,7 @@ gulp.task("watch-custom-scss", gulp.series('select-view', (cb) => {
         cb();
         return;
 	}
-    gulp.watch([config.customScssDir() + "/**/*.scss"], ["custom-scss"]);
+    gulp.watch([config.customScssDir() + "/**/*.scss"], gulp.series('custom-scss'));
     cb();
 }));
 

--- a/gulp/tasks/03-scss.js
+++ b/gulp/tasks/03-scss.js
@@ -105,7 +105,7 @@ gulp.task("watch-custom-scss", gulp.series('select-view', (cb) => {
         cb();
         return;
 	}
-    gulp.watch([config.customScssDir() + "/**/*.scss"], gulp.series('custom-scss'));
+    gulp.watch([config.customScssDir() + "/**/*.scss"], {allowEmpty:true},  gulp.series('custom-scss'));
     cb();
 }));
 

--- a/gulp/tasks/03-scss.js
+++ b/gulp/tasks/03-scss.js
@@ -105,7 +105,7 @@ gulp.task("watch-custom-scss", gulp.series('select-view', (cb) => {
         cb();
         return;
 	}
-    gulp.watch([config.customScssDir() + "/**/*.scss"], {allowEmpty:true},  gulp.series('custom-scss'));
+    gulp.watch(gulp.src([config.customScssDir() + "/**/*.scss"],{allowEmpty:true}), gulp.series('custom-scss'));
     cb();
 }));
 

--- a/gulp/tasks/04-custom-css.js
+++ b/gulp/tasks/04-custom-css.js
@@ -14,7 +14,7 @@ let buildParams = config.buildParams;
 
 
 gulp.task('watch-css', gulp.series('select-view', (cb) => {
-    gulp.watch([buildParams.customCssMainPath(),buildParams.customNpmCssPath(),'!'+buildParams.customCssPath()],gulp.series('custom-css'));
+    gulp.watch([buildParams.customCssMainPath(),buildParams.customNpmCssPath(),'!'+buildParams.customCssPath()], {interval: 1000, usePolling: true}, gulp.series('custom-css'));
     cb();
 }));
 

--- a/gulp/tasks/09-images.js
+++ b/gulp/tasks/09-images.js
@@ -7,7 +7,7 @@ const config = require('../config.js');
 let buildParams = config.buildParams;
 
 gulp.task('watch-img', () => {
-    gulp.watch([buildParams.viewImgDir(), '!'+buildParams.customNpmImgPath()],gulp.series('custom-img'));
+    gulp.watch([buildParams.viewImgDir(), '!'+buildParams.customNpmImgPath()], {interval: 1000, usePolling: true}, gulp.series('custom-img'));
 });
 
 gulp.task('custom-img', () => {

--- a/gulp/tasks/09-images.js
+++ b/gulp/tasks/09-images.js
@@ -7,7 +7,7 @@ const config = require('../config.js');
 let buildParams = config.buildParams;
 
 gulp.task('watch-img', () => {
-    gulp.watch([buildParams.viewImgDir(), '!'+buildParams.customNpmImgPath()],['custom-img']);
+    gulp.watch([buildParams.viewImgDir(), '!'+buildParams.customNpmImgPath()],gulp.series('custom-img'));
 });
 
 gulp.task('custom-img', () => {


### PR DESCRIPTION
hi @noamamit92 , many thanks for recent updates and merge my pull request.

i tried to rebuild my primo-explore-devenv docker image and ran into a few issues.

- the last parameter for gulp.watch should be a function and not ["custom-scss"] or ['custom-img'], so i changed this to gulp.series().
- when using --useScss parameter without scss/main.scss devenv fails, therefore i added {allowEmpty:true}
- it seems there is a problem for gulp.watch on files inside docker container, devenv does not stop to bulild custom.js, event though there are no file changes.  i found a suggestion on google and added  {interval: 1000, usePolling: true},  that makes it work again for me inside docker.

please review, thx

