### PR TITLE
fix node-modules tasks, use gulp4-run-sequence and add callback

### DIFF
--- a/gulp/tasks/01-custom-html-templates.js
+++ b/gulp/tasks/01-custom-html-templates.js
@@ -20,7 +20,7 @@ function parseModuleName(){
 
 function prepareTempltesWithBrowserify(){
     let module = parseModuleName();
-    gulp.src(buildParams.viewHtmlDir() + '/templates/**/*.html')
+    return gulp.src(buildParams.viewHtmlDir() + '/templates/**/*.html')
         .pipe(templateCache({
             filename:'customTemplates.js',
             module: module,
@@ -33,10 +33,10 @@ function prepareTempltesWithBrowserify(){
 
 function prepareTemplates() {
     if(config.getBrowserify()){
-        prepareTempltesWithBrowserify();
+        return prepareTempltesWithBrowserify();
     }
     else{
-        gulp.src([buildParams.viewHtmlDir() + '/templates/**/*.html', buildParams.customNpmHtmlPath()])
+        return gulp.src([buildParams.viewHtmlDir() + '/templates/**/*.html', buildParams.customNpmHtmlPath()])
             .pipe(templateCache({
                 filename:'customTemplates.js',
                 templateHeader: 'app.run(function($templateCache) {',

--- a/gulp/tasks/01-custom-html-templates.js
+++ b/gulp/tasks/01-custom-html-templates.js
@@ -50,6 +50,5 @@ function prepareTemplates() {
 }
 
 gulp.task('custom-html-templates', gulp.series('select-view', (cb) => {
-    prepareTemplates();
-    cb();
+    prepareTemplates().on('end', cb);
 }))

--- a/gulp/tasks/02-custom-js.js
+++ b/gulp/tasks/02-custom-js.js
@@ -25,12 +25,11 @@ gulp.task('watch-js', gulp.series('select-view', (cb) => {
 
 gulp.task('custom-js', gulp.series('select-view', 'custom-html-templates',(cb) => {
     if (config.getBrowserify()) {
-        return buildByBrowserify();
+        buildByBrowserify().on('end', cb);
     }
     else {
-        return buildByConcatination();
+        buildByConcatination().on('end', cb);
     }
-    cb();
 }));
 
 function getBrowserifyBabelPlugins() {

--- a/gulp/tasks/02-custom-js.js
+++ b/gulp/tasks/02-custom-js.js
@@ -24,15 +24,13 @@ gulp.task('watch-js', gulp.series('select-view', (cb) => {
 
 
 gulp.task('custom-js', gulp.series('select-view', 'custom-html-templates',(cb) => {
-   if(config.getBrowserify()) {
-       cb();
-       return buildByBrowserify();
-   }
-   else {
-       cb();
-       return buildByConcatination();
-   }
-
+    if (config.getBrowserify()) {
+        return buildByBrowserify();
+    }
+    else {
+        return buildByConcatination();
+    }
+    cb();
 }));
 
 function getBrowserifyBabelPlugins() {

--- a/gulp/tasks/07-primo-node-modules.js
+++ b/gulp/tasks/07-primo-node-modules.js
@@ -5,7 +5,7 @@ let del = require("del");
 let execSync = require('child_process').execSync;
 let gulp = require("gulp");
 let gutil = require("gulp-util");
-let runSequence = require("run-sequence");
+let runSequence = require("gulp4-run-sequence");
 
 /**
  * Metatask that executes the two atomic tasks in order
@@ -19,7 +19,8 @@ let runSequence = require("run-sequence");
  */
 gulp.task("reinstall-primo-node-modules", gulp.series('select-view', function(cb) {
 	if (config.getReinstallNodeModules()) {
-		runSequence(["delete-primo-node-modules", "install-primo-node-modules"]);
+		runSequence("delete-primo-node-modules", "install-primo-node-modules", cb);
+		return;
 	}
 	cb();
 }));
@@ -27,7 +28,7 @@ gulp.task("reinstall-primo-node-modules", gulp.series('select-view', function(cb
 /**
  * Deletes all primo-explore related node modules of the view package.
  */
-gulp.task("delete-primo-node-modules", function() {
+gulp.task("delete-primo-node-modules", function(cb) {
 	gutil.log("Starting deletion of the view package's primo explore related node modules.");
 
 	del.sync([
@@ -35,6 +36,7 @@ gulp.task("delete-primo-node-modules", function() {
 	]);
 
 	gutil.log("Finished deletion of the view package's primo explore related node modules.");
+	cb();
 });
 
 /**
@@ -44,7 +46,7 @@ gulp.task("delete-primo-node-modules", function() {
  * This requires that all relevant primo-explore modules need to be referenced
  * in the package.json file in the root folder of the view package.
  */
-gulp.task("install-primo-node-modules", function() {
+gulp.task("install-primo-node-modules", function(cb) {
 	gutil.log("Starting re-installation of the view package's node modules using >npm install< command.");
 
 	execSync('npm install', {
@@ -64,4 +66,5 @@ gulp.task("install-primo-node-modules", function() {
 	});
 
 	gutil.log("Finished re-installation of the view package's node modules using >npm install< command.");
+	cb();
 });


### PR DESCRIPTION
gulp4 fix makes the reinstall-primo-node-modules, delete-primo-node-modules and install-primo-node-modules work again.