### PR TITLE
fix autoprefixer browsers option and replace by browserslist in package.json

### DIFF
--- a/gulp/tasks/03-scss.js
+++ b/gulp/tasks/03-scss.js
@@ -76,7 +76,6 @@ gulp.task('compile-scss',() => {
         // .pipe(sourcemaps.init())
         .pipe(sass())
         .pipe(autoprefixer({    
-            browsers: ['last 2 versions'],        
             cascade: false
         }));
     let colorStream = allCss
@@ -136,7 +135,6 @@ gulp.task("custom-scss", gulp.series('select-view', (cb) => {
 		// .pipe(sourcemaps.init())
 		.pipe(sass())
 		.pipe(autoprefixer({
-				browsers: ['last 2 versions'],
 				cascade: false
 		}))
 		.pipe(rename("custom-scss-compiled.css"))

--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
   "engines": {
     "node": ">=10.0"
   },
+  "browserslist": [
+    "last 2 version",
+    "> 2%"
+  ],
   "repository": "https://github.com/ExLibrisGroup/primo-explore-devenv",
   "dependencies": {}
 }


### PR DESCRIPTION
This patch should fix the following autoprefixer warning when running gulp `app-css` task.

 ```
Creating network "primo-explore-vbk_default" with the default driver
[05:36:30] Using gulpfile /app/primo-explore-devenv/gulpfile.js
[05:36:30] Starting 'app-css'...
[05:36:30] Starting 'extract-scss-files'...
https://search.vbk.ac.at:443/primo-explore/lib/scsss.tar.gz
[05:36:30] Finished 'extract-scss-files' after 336 ms
[05:36:30] Starting 'color-variables'...
[05:36:30] Finished 'color-variables' after 38 ms
[05:36:30] Starting 'compile-scss'...

  Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option can cause errors. Browserslist config 
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.

  If you really need to use option, rename it to overrideBrowserslist.

  Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist
```
