### PR TITLE
Update mtime on scss target file

### DIFF
--- a/gulp/tasks/03-scss.js
+++ b/gulp/tasks/03-scss.js
@@ -28,6 +28,7 @@ let  fs = require('fs');
 let del = require('del');
 let lodashMerge = require('lodash/merge');
 let gutil = require('gulp-util');
+let touch = require('gulp-touch-cmd');
 
 gulp.task('cleanup',()=> del(['www']));
 
@@ -138,7 +139,8 @@ gulp.task("custom-scss", gulp.series('select-view', (cb) => {
 				cascade: false
 		}))
 		.pipe(rename("custom-scss-compiled.css"))
-		.pipe(gulp.dest(config.viewCssDir()));
+		.pipe(gulp.dest(config.viewCssDir()))
+		.pipe(touch());
 
 	gutil.log("End Creating custom CSS from custom SCSS");
     cb();

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gulp-sourcemaps": "2.6.5",
     "gulp-streamify": "1.0.2",
     "gulp-template": "5.0.0",
+    "gulp-touch-cmd": "0.0.1",
     "gulp-uglify": "3.0.2",
     "gulp-util": "3.0.8",
     "gulp-wrap": "^0.15.0",


### PR DESCRIPTION
Modify the `custom-scss` task so that it updates the mtime on the target file (`css/custom-scss-compiled.css)`.

Why is this needed? Normally, `gulp.dest()` will simply propagate the source file's mtime to the target file. In this case, the source file is `scss/main.scss`. 

Suppose your `main.scss` file contains the following line: 

```
@import "variables";
```

If you modify `scss/_variables.scss`, the `watch-custom-scss` task will trigger an update to `css/custom-scss-compiled.css)`. *However*, the updated file's mtime will remain unchanged because the mtime on `scss/main.scss` has not changed. As a result, the `watch-css` task will not know that `css/custom1.css` needs to be rebuilt. 

I'm guessing this is an unintended side-effect of changing the `watch-css` task to use polling instead of filesystem events (f34630e74d060620fdc951a08f9ed9de974747c0). Simply touching the target file seems like the most straightforward solution. 