### PR TITLE
Allows css|html|img|js subdirectories to be gitignore excluded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-primo-explore/custom/
+primo-explore/custom/*/*/*
 primo-explore/tmp/
 
 !primo-explore/custom/.gitignore

--- a/primo-explore/custom/.gitignore
+++ b/primo-explore/custom/.gitignore
@@ -1,1 +1,10 @@
-# Add entries to prefixed with '!' to unhide your view files
+*.*
+# Add entries to prefixed with '!' to unhide your view files:
+# Eg:
+# !*/css/**
+# !*/html/**
+# !*/img/**
+# !*/js/**
+
+
+


### PR DESCRIPTION
I think that original author who changed the .gitignore files (see [PR #106](https://github.com/ExLibrisGroup/primo-explore-devenv/pull/106) ) expected the .gitignore within the 'custom' directory to override that of the project's root and so un-gitignore the css, html, img and js sub-directories. However, this would never have been possible because if you .gitignore an entire directory, then you cannot use ! to un-gitignore it futher down.  This PR fixes that. See https://git-scm.com/docs/gitignore.

PS I'm raising this PR from my personal Github account but I have also made this .gitignore change in the [britishlibrary](https://github.com/britishlibrary/BL-primo-explore-devenv/pull/3/) fork of your ExLibris/primo-explore-devenv as I work there. 